### PR TITLE
Add architectures stanza

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,9 @@ description: |
 grade: stable
 confinement: strict
 
+architectures:
+  - build-on: amd64
+
 parts:
   discord:
     plugin: dump
@@ -26,11 +29,8 @@ parts:
     after:
       - desktop-gtk2
     build-packages:
-      # Discord only publishes debs for amd64, so fail builds on other architectures.
-      - on amd64:
-        - curl
-        - sed
-      - else fail
+      - curl
+      - sed
     stage-packages:
       - libasound2
       - libatomic1


### PR DESCRIPTION
Adding the architectures stanza which means we don't waste time building on unsupported architectures. See [this thread](https://forum.snapcraft.io/t/architectures/4972) for more details.