### PR TITLE
Moving to GNOME 3.28 platform snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ and text chat for gamers that's free, secure, and works on both your desktop
 and phone"</i>. It works on Ubuntu, Fedora, Debian, and other major Linux
 distributions.</p>
 <p align="center">
-<a href="https://build.snapcraft.io/user/snapcrafters/discord"><img src="https://build.snapcraft.io/badge/snapcrafters/discord.svg" alt="Snap Status"></a>
+<a href="https://build.snapcraft.io/badge/YamiYukiSenpai/discord.svg"><img src="https://build.snapcraft.io/badge/snapcrafters/discord.svg" alt="Snap Status"></a>
 </p>
-
 ## Install
 
     sudo snap install discord

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
  servers and hassling with Skype. Simplify your life.
 
 grade: devel
-confinement: strict
+confinement: devmode
 
 architectures:
   - build-on: amd64

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ architectures:
   - build-on: amd64
 
 plugs:
-  gnome-3-26-1604:
+  gnome-3-28-1804:
     interface: content
     target: $SNAP/gnome-platform
     default-provider: gnome-3-28-1804

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,5 @@
 name: discord-yamiyukisenpai
+base: core18
 version: latest
 version-script: cat $SNAPCRAFT_STAGE/version
 summary: Free voice and text chat

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
  works on both your desktop and phone. Stop paying for TeamSpeak
  servers and hassling with Skype. Simplify your life.
 
-grade: stable
+grade: devel
 confinement: strict
 
 architectures:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,7 @@ description: |
  servers and hassling with Skype. Simplify your life.
 
 grade: devel
-confinement: devmode
+confinement: strict
 
 architectures:
   - build-on: amd64

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: discord
+name: discord-yamiyukisenpai
 version: latest
 version-script: cat $SNAPCRAFT_STAGE/version
 summary: Free voice and text chat
@@ -17,7 +17,7 @@ plugs:
   gnome-3-26-1604:
     interface: content
     target: $SNAP/gnome-platform
-    default-provider: gnome-3-26-1604
+    default-provider: gnome-3-28-1804
   gtk-3-themes:
     interface: content
     target: $SNAP/data-dir/themes
@@ -36,10 +36,10 @@ parts:
     plugin: nil
     build-packages:
       - software-properties-common
-    override-pull: |
-      add-apt-repository -y ppa:ubuntu-desktop/gnome-3-26
-      apt -y update
-      apt -y upgrade
+    #override-pull: |
+      #add-apt-repository -y ppa:ubuntu-desktop/gnome-3-26
+      #apt -y update
+      #apt -y upgrade
 
   libappindicator:
     plugin: nil


### PR DESCRIPTION
Since 3.26 is broken on Eoan, I tried moving the platform snap to `gnome-3-28-1804`.  It seems to work, though the size got bigger.

Still a total noob at snaps, and I had to use the desktop-helper thingy to make it work.  Not sure where `desktop-gnome-platform`, so I replaced it with the helper (sorta based it on the one I found on GIMP's `snapcraft.yaml` file).  