### PR TITLE
WIP: Update to use gnome-3-34 snapcraft extension

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,12 +13,6 @@ confinement: strict
 architectures:
   - build-on: amd64
 
-plugs:
-  gnome-3-28-1804:
-    interface: content
-    target: $SNAP/gnome-platform
-    default-provider: gnome-3-28-1804
-
 parts:
   discord:
     plugin: dump
@@ -44,7 +38,6 @@ parts:
       - libnss3
       - libxss1
       - xdg-utils
-      - libappindicator3-1
     prime:
       - -usr/bin/xdg-open
   cleanup:
@@ -58,7 +51,7 @@ parts:
 
 apps:
   discord:
-    extensions: [gnome-3-28]
+    extensions: [gnome-3-34]
     command: usr/share/discord/Discord
     desktop: usr/share/applications/discord.desktop
     environment:


### PR DESCRIPTION
This change does two things:
1. updates the snapcraft extension used from gnome-3-28 to gnome-3-34
2. Removes the need to stage libappindicator because it is included in the gnome-3-34-1804 platform snap ([see that MR here](https://gitlab.gnome.org/Community/Ubuntu/gnome-sdk/merge_requests/10))