### PR TITLE
GNOME 3.28 & Autostart

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,12 +13,6 @@ confinement: strict
 architectures:
   - build-on: amd64
 
-plugs:
-  gnome-3-28-1804:
-    interface: content
-    target: $SNAP/gnome-platform
-    default-provider: gnome-3-28-1804
-
 parts:
   discord:
     plugin: dump
@@ -37,7 +31,6 @@ parts:
       - curl
       - sed
     stage-packages:
-      - libasound2
       - libatomic1
       - libc++1
       - libgconf2-4
@@ -73,12 +66,8 @@ apps:
       # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
     plugs:
-      - bluez
       - browser-support
       - camera
-      - desktop
-      - desktop-legacy
-      - gsettings
       - home
       - mount-observe
       - network
@@ -90,5 +79,3 @@ apps:
       - screen-inhibit-control
       - system-observe
       - unity7
-      - wayland
-      - x11

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,6 +54,7 @@ apps:
   discord:
     extensions: [gnome-3-28]
     command: usr/share/discord/Discord --no-sandbox
+    autostart: discord.desktop
     desktop: usr/share/applications/discord.desktop
     environment:
       # Correct the TMPDIR path for Chromium Framework/Electron to

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,17 @@ architectures:
   - build-on: amd64
 
 parts:
+  libappindicator:
+    plugin: nil
+    stage-packages:
+      - libappindicator3-1
+    prime:
+      - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libdbusmenu*.so*
+      - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libappindicator*.so*
+      - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libindicator*.so*
+
   discord:
+    after: [libappindicator]
     plugin: dump
     source: "https://discordapp.com/api/download?platform=linux&format=deb"
     source-type: deb
@@ -37,11 +47,10 @@ parts:
       - libnss3
       - libxss1
       - xdg-utils
-      - libappindicator3-1
     prime:
       - -usr/bin/xdg-open
   cleanup:
-    after: [ discord ]
+    after: [discord]
     plugin: nil
     build-snaps: [ gnome-3-28-1804 ]
     override-prime: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,6 @@ parts:
     stage-packages:
       - libatomic1
       - libc++1
-      - libgconf2-4
       - libnspr4
       - libnss3
       - libxss1


### PR DESCRIPTION
This pull request completes the transition to the GNOME 3.38 platform snap and also adds autostart.