### PR TITLE
added unity7 plug to allow badge in the ubuntu-dock Fixes #125

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -103,3 +103,4 @@ apps:
       - screen-inhibit-control
       - shmem
       - system-observe
+      - unity7


### PR DESCRIPTION
We need to allow access to the unity7 interface to allow the badge to work in the Ubuntu Dock