### PR TITLE
Fix first run update prompt when discord is outdated

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,9 @@ parts:
     override-pull: |
       cat <<'EOF' > disable-updater.sh
       #!/bin/bash
+      if [ ! -d "$SNAP_USER_DATA"/.config/discord ]; then
+        mkdir -p "$SNAP_USER_DATA"/.config/discord
+      fi
       CONFIG_FILE="$SNAP_USER_DATA"/.config/discord/settings.json
       if ! [ -f "$CONFIG_FILE" ]; then
         echo '{}' > "$CONFIG_FILE"


### PR DESCRIPTION
When Discord is installed onto a system for the first time, and the snap contains an outdated version of Discord, attempting to run Discord will prompt the user to update without any bypass ability. This is due to the `settings.json` not being created on first launch due to the directory not being created at the time we attempt to write our override setting into the json file.

- Create the `$SNAP_USER_DATA/.config/discord` directory if it doesn't already exist when amending the `settings.json` file.

Signed-off-by: Dani Llewellyn <diddledani@ubuntu.com>