### PR TITLE
ci: add release update and screenshot gathering automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"

--- a/.github/testing-issue-template.md
+++ b/.github/testing-issue-template.md
@@ -1,0 +1,44 @@
+---
+title: Call for testing `{{ env.SNAP_NAME }}`
+labels: testing
+---
+
+A new version ({{ env.version }}) of `{{ env.SNAP_NAME }}` was just pushed to the `{{ env.CHANNEL }}` channel [in the snap store](https://snapcraft.io/{{ env.SNAP_NAME }}). The following revisions are available.
+
+{{ env.table }}
+
+## Automated screenshots
+
+The snap will be installed in a VM automatically; screenshots will be posted as a comment on this issue shortly.
+
+## How to test it manually
+
+1. Stop the application if it was already running
+1. Upgrade to this version by running
+
+   ```shell
+   snap refresh {{ env.SNAP_NAME }} --{{ env.CHANNEL }}
+   ```
+
+1. Start the app and test it out.
+1. Finally, add a comment below explaining whether this app is working, and **include the output of the following command**.
+
+   ```shell
+   snap version; lscpu | grep Architecture; snap info {{ env.SNAP_NAME }} | grep installed
+   ```
+
+## How to release it
+
+Maintainers can promote this to stable by commenting `/promote <rev>[,<rev>] stable [done]`.
+
+> For example
+>
+> - To promote a single revision, run `/promote <rev> stable`
+> - To promote multiple revisions, run `/promote <rev>,<rev> stable`
+> - To promote a revision and close the issue, run `/promote <rev>,<rev> stable done`
+
+You can promote all revisions that were just built with:
+
+```
+/promote {{ env.revisions }} stable done
+```

--- a/.github/vmctl
+++ b/.github/vmctl
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default VM attributes - tuned for Github Actions runners by default
+VM_NAME="${VM_NAME:-test-vm}"
+VM_SERIES="${VM_SERIES:-22.04}"
+VM_CPUS="${VM_CPUS:=1}"
+VM_MEM_GIB="${VM_MEM_GIB:=6}"
+VM_DISK_GIB="${VM_DISK_GIB:=12}"
+
+build_runner_script() {
+  vmctl_runner="$(mktemp)"
+  chmod +x "$vmctl_runner"
+  cat <<-EOF > "$vmctl_runner"
+#!/usr/bin/env bash
+
+export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
+export WAYLAND_DISPLAY=wayland-0
+export DISPLAY=:0.0
+export HOME=/home/ubuntu
+
+exec "\$@"
+EOF
+
+  echo "$vmctl_runner"
+}
+
+# If we're on a Github Actions Runner, enable KVM.
+enable_kvm_gha() {
+  if [[ -x "${GITHUB_ACTIONS:-}" ]]; then
+    echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger --name-match=kvm
+  fi
+}
+
+# Starts a desktop VM and waits for the agent to be running inside.
+prepare_vm() {
+  # Start the VM
+  lxc launch "images:ubuntu/${VM_SERIES}/desktop" "${VM_NAME}" --vm \
+    -c limits.cpu="${VM_CPUS}" -c limits.memory="${VM_MEM_GIB}GiB" -d root,size="${VM_DISK_GIB}GiB"
+
+  # Wait for the VM agent to be running
+  while ! lxc exec test-vm -- cat /etc/hostname &>/dev/null; do 
+    sleep 2
+  done
+
+  # Push script runner into the VM
+  lxc file push "$(build_runner_script)" test-vm/bin/vmctl-runner
+  lxc exec test-vm -- chmod 755 /bin/vmctl-runner
+
+  # Install gnome-screenshot
+  lxc exec test-vm -- apt-get update
+  lxc exec test-vm -- apt-get install -y gnome-screenshot
+
+  # Kill the gnome initial setup wizard
+  pid="$(lxc exec test-vm -- pidof gnome-initial-setup)"
+  lxc exec test-vm -- kill -9 "$pid"
+}
+
+# Exec a command in the VM using the wrapper.
+exec_in_vm() {
+  lxc exec test-vm -- sudo -u ubuntu bash -c "/bin/vmctl-runner $@"
+}
+
+# Takes a screenshot of the full screen and pulls the file back from the VM to a file
+# named "screenshot-screen.png", and uploads to imgur, returning the URL
+screenshot_full() {
+  # Take a screenshot of the whole screen in the VM
+  exec_in_vm "gnome-screenshot -f /home/ubuntu/screen.png"
+  # Pull the screenshot back to the host
+  lxc file pull test-vm/home/ubuntu/screen.png screenshot-screen.png
+}
+
+# Takes a screenshot of the active window and pulls the file back from the VM to a file
+# named "screenshot-window.png", and uploads to imgur, returning the URL
+screenshot_window() {
+  # Take a screenshot of the active window in the VM
+  exec_in_vm "gnome-screenshot -w -f /home/ubuntu/window.png"
+  # Pull the screenshot back to the host
+  lxc file pull test-vm/home/ubuntu/window.png screenshot-window.png
+}
+
+# Print the usage statement and exit the program
+usage() {
+  echo "Usage: vmctl [prepare | push-snap <file> | exec <string> | screenshot-full | screenshot-window"]
+  exit 1
+}
+
+# Parse the subcommand and exit if empty, printing the usage
+command="${1:-}"; shift
+if [[ -z "$command" ]]; then
+  usage
+fi
+
+case "$command" in
+  "prepare")
+    enable_kvm_gha
+    prepare_vm
+    ;;
+  "exec")
+    exec_in_vm "$@"
+    ;;
+  "screenshot-full")
+    screenshot_full
+    ;;
+  "screenshot-window")
+    screenshot_window
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/.github/workflows/snap-store-promote-to-stable.yml
+++ b/.github/workflows/snap-store-promote-to-stable.yml
@@ -1,0 +1,89 @@
+name: 📦 Promote to stable
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  issues: write
+
+env:
+  SNAP_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  promote:
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    if: |
+      ( !github.event.issue.pull_request )
+      && contains(github.event.comment.body, '/promote ')
+      && contains(github.event.*.labels.*.name, 'testing')
+    steps:
+      - id: command
+        uses: xt0rted/slash-command-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          command: promote
+          reaction: "true"
+          reaction-type: "eyes"
+          allow-edits: "false"
+          permission-level: write
+      - id: promote
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_STABLE }}
+        run: |
+          echo "The command was '${{ steps.command.outputs.command-name }}' with arguments '${{ steps.command.outputs.command-arguments }}'"
+          arguments=(${{ steps.command.outputs.command-arguments }})
+          revision=${arguments[0]}
+          channel=${arguments[1]}
+          done=${arguments[2]}
+
+          # Validation checks
+          re='^[0-9]+([,][0-9]+)*$'
+          if [[ ! "$revision" =~ $re ]]; then
+            echo "revision must be a number or a comma seperated list of numbers, not '$revision'!"
+            exit 1
+          fi
+          if [[ "$channel" != "stable"  ]]; then
+            echo "I can only promote to stable, not '$channel'!"
+            exit 1
+          fi
+          if [[ -n "$done" && "$done" != "done"  ]]; then
+            echo "The third argument should be 'done' or empty"
+            exit 1
+          fi
+
+          # Install Snapcraft
+          sudo snap install --classic snapcraft
+          sudo chown root:root /
+
+          # Iterate over each specified revision and release
+          revs=$(echo $revision | tr "," "\n")
+          released_revs=()
+
+          for r in $revs; do
+            snapcraft release $SNAP_NAME "$r" "$channel"
+            released_revs+=("$r")
+          done
+
+          echo "revisions=${released_revs[@]}" >> $GITHUB_OUTPUT
+          echo "channel=$channel" >> $GITHUB_OUTPUT
+          echo "done=$done" >> $GITHUB_OUTPUT
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'The following revisions were released to the `${{ steps.promote.outputs.channel }}` channel: `${{ steps.promote.outputs.revisions }}`'
+            })          
+            if ("${{ steps.promote.outputs.done }}" === "done") {
+              github.rest.issues.update({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'closed'
+              })
+            }

--- a/.github/workflows/snap-store-publish-to-candidate.yml
+++ b/.github/workflows/snap-store-publish-to-candidate.yml
@@ -1,0 +1,249 @@
+name: 📦 Publish to candidate
+
+on:
+  # Run the workflow each time new commits are pushed to the candidate branch. 
+  push:
+    branches: [ "candidate" ]
+  # Allow the workflow to be started manually from the Actions tab.
+  workflow_dispatch:
+  # Allow the workflow to be started by another workflow.
+  workflow_call:
+    secrets:
+      SNAP_STORE_CANDIDATE:
+        required: true
+      LP_BUILD_SECRET:
+        required: true
+      SNAPCRAFTERS_BOT_COMMIT:
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Permissions for GITHUB_TOKEN
+permissions:
+  contents: read
+  issues: write
+
+env:
+  # Use the name of the repo as the name of the snap
+  SNAP_NAME: ${{ github.event.repository.name }}
+  # Hardcoded git branch and Snap Store channel channel
+  CHANNEL: 'candidate'
+
+jobs:
+  get_archs:
+    name: Compute architectures
+    runs-on: ubuntu-latest
+    outputs:
+      archs: ${{ steps.archs.outputs.archs }}
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHANNEL }}
+
+      - name: Compute architectures
+        id: archs
+        run: |
+          # Handle the case where architectures is a simple list of strings
+          archs="$(cat snap/snapcraft.yaml | yq -I=0 -o=json '[.architectures[]]')"
+
+          # Handle the case where architectures is a list of objects
+          if echo "$archs" | grep -q "build-on"; then
+              archs="$(cat snap/snapcraft.yaml | yq -I=0 -o=json '[.architectures[]."build-on"]')"
+          fi
+
+          echo "archs=$archs" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: "Build & publish"
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    needs: [get_archs]
+    strategy:
+      matrix:
+        # Parse the list of architectures from the output we created above (one job per arch)
+        architecture: ${{ fromJSON(needs.get_archs.outputs.archs) }}
+    outputs:
+      version: ${{ steps.build.outputs.version }}
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHANNEL }}
+
+      - name: Setup snapcraft
+        env:
+          LP_BUILD_SECRET: ${{ secrets.LP_BUILD_SECRET }}
+        run: |
+          sudo snap install snapcraft --classic
+
+          # Setup Launchpad credentials
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad
+          echo "$LP_BUILD_SECRET" > ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "Github Actions"
+
+          # Install moreutils so we have access to sponge
+          sudo apt-get update; sudo apt-get install -y moreutils
+
+      - name: Remote build the snap
+        id: build
+        env:
+          ARCHITECTURE: ${{ matrix.architecture }}
+        run : |
+          # Remove the architecture definition from the snapcraft.yaml due to:
+          # https://bugs.launchpad.net/snapcraft/+bug/1885150
+          cat snap/snapcraft.yaml | yq 'del(.architectures)' | sponge snap/snapcraft.yaml
+
+          snapcraft remote-build --launchpad-accept-public-upload --build-for=${ARCHITECTURE}
+
+          version="$(cat snap/snapcraft.yaml | yq -r '.version')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "snap=${{ env.SNAP_NAME }}_${version}_${ARCHITECTURE}.snap" >> "$GITHUB_OUTPUT"
+
+      - name: Review the built snap
+        uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          isClassic: 'false'
+
+      - name: Publish the built snap
+        id: publish
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
+          SNAP_FILE: ${{ steps.build.outputs.snap }}
+          ARCHITECTURE: ${{ matrix.architecture }}
+        run: |
+          snapcraft push "$SNAP_FILE" --release="$CHANNEL"
+
+  # Create an issue using the template that asks maintainers to test the snap, and take
+  # action to promote the revisions to stable if testing is successful.
+  create_issue:
+    name: "Create call for testing"
+    environment: "Candidate Branch"
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v4
+      
+      - name: Setup snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+
+      - name: Write the arch/rev table
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_CANDIDATE }}
+        id: build
+        run: |
+          # Build the initial structure for the HTML table including the header row.
+          table="<table><thead><tr><th>CPU Architecture</th><th>Revision</th></tr></thead><tbody>"
+
+          # Declare an array to keep track of the revisions we've seen
+          revisions=()
+
+          # Iterate over the architectures specified in the snapcraft.yaml
+          for arch in $(cat snap/snapcraft.yaml | yq '.architectures[]'); do
+              rev="$(snapcraft list-revisions "${{ env.SNAP_NAME }}" --arch "$arch" | grep "latest/candidate*" | head -n1 | cut -d' ' -f1)"
+              revisions+=("$rev")
+              # Add a row to the HTML table
+              table="${table}<tr><td>${arch}</td><td>${rev}</td></tr>"
+          done
+
+          # Add the closing tags for the table
+          table="${table}</tbody></table>"
+
+          # Get a comma separated list of revisions
+          printf -v joined '%s,' "${revisions[@]}"
+
+          echo "revisions=${joined%,}" >> "$GITHUB_OUTPUT"
+          echo "table=${table}" >> "$GITHUB_OUTPUT"
+
+      - name: Create call for testing issue
+        uses: JasonEtco/create-an-issue@v2
+        id: comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          revisions: ${{ steps.build.outputs.revisions }}
+          table: ${{ steps.build.outputs.table }}
+          version: ${{ needs.build.outputs.version }}
+        with:
+          filename: .github/testing-issue-template.md
+    outputs:
+      issue_number: ${{ steps.comment.outputs.number }}
+
+  # Deploy the snap inside a desktop VM and grab screenshots of the desktop, and of
+  # the application, then post them as a comment on the issue created above.
+  grab-screenshots:
+    name: Gather screenshots
+    environment: "Candidate Branch"
+    needs: 
+      - build
+      - create_issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+
+      - name: Prepare VM
+        run: |
+          .github/vmctl prepare
+          .github/vmctl exec "sudo snap install ${{ env.SNAP_NAME }} --channel candidate"
+          .github/vmctl exec "snap run ${{ env.SNAP_NAME }} &>/home/ubuntu/${{ env.SNAP_NAME }}.log &"
+          sleep 20
+
+      - name: Gather screenshots
+        run: |
+          .github/vmctl screenshot-full
+          .github/vmctl screenshot-window
+
+      - name: Output application logs
+        run: |
+          .github/vmctl exec "cat /home/ubuntu/${{ env.SNAP_NAME }}.log"
+
+      - name: Checkout snapcrafters/ci-screenshots
+        uses: actions/checkout@v4
+        with: 
+          repository: snapcrafters/ci-screenshots
+          path: ci-screenshots
+          token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
+
+      - name: Upload screenshots to snapcrafters/ci-screenshots
+        id: screenshots
+        run: |
+          file_prefix="$(date +%Y%m%d)-${{ env.SNAP_NAME }}-${{ needs.create_issue.outputs.issue_number }}"
+
+          pushd ci-screenshots
+          mv ../screenshot-screen.png "${file_prefix}-screen.png"
+          mv ../screenshot-window.png "${file_prefix}-window.png"
+
+          git config --global user.email "merlijn.sebrechts+snapcrafters-bot@gmail.com"
+          git config --global user.name "Snapcrafters Bot"
+
+          git add -A .
+          git commit -m "data: screenshots for snapcrafters/${{ env.SNAP_NAME }}#${{ needs.create_issue.outputs.issue_number }}"
+          git push origin main
+
+          echo "screen=https://raw.githubusercontent.com/snapcrafters/ci-screenshots/main/${file_prefix}-screen.png" >> "$GITHUB_OUTPUT"
+          echo "window=https://raw.githubusercontent.com/snapcrafters/ci-screenshots/main/${file_prefix}-window.png" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on call for testing issue with screenshots
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: ${{ needs.create_issue.outputs.issue_number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `The following screenshots were taken during automated testing:
+
+              ![window](${{ steps.screenshots.outputs.window }})
+
+              ![screen](${{ steps.screenshots.outputs.screen }})
+              `
+            })

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -1,0 +1,39 @@
+name: 🔄 Sync version with upstream
+
+on:
+  # Runs at 10:00 UTC every day
+  schedule:
+    - cron:  '0 10 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+
+jobs:
+  sync-version:
+    name: "Update snapcraft.yaml"
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
+      - name: Fetch release version
+        run: |
+          DEB_API="https://discord.com/api/download?platform=linux&format=deb"
+          DEB_URL=$(curl -w "%{url_effective}\n" -I -L -s -S "${DEB_API}" -o /dev/null)
+          VERSION=$(echo "${DEB_URL}" | cut -d'/' -f6)
+          sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml
+      - name: Check for modified files
+        id: git-check
+        run: |
+          MODIFIED=$([ -z "`git status --porcelain`" ] && echo "false" || echo "true")
+          echo "modified=$MODIFIED" >> $GITHUB_OUTPUT
+      - name: Commit latest release version
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'Snapcrafters Bot'
+          git config --global user.email 'merlijn.sebrechts+snapcrafters-bot@gmail.com'
+          git commit -am "Automatic sync to latest release"
+          git push
+    outputs:
+      modified: ${{ steps.git-check.outputs.modified }}

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,25 +1,31 @@
 name: 🧪 Test snap can be built on x86_64
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
-    
+    branches: [ "**" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Permissions for GITHUB_TOKEN
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - uses: snapcore/action-build@v1
+      - name: Build snap
+        uses: snapcore/action-build@v1
         id: build
 
-      - uses: diddlesnaps/snapcraft-review-action@v1
+      - name: Review snap
+        uses: diddlesnaps/snapcraft-review-action@v1
         with:
           snap: ${{ steps.build.outputs.snap }}
           isClassic: 'false'
-          # Plugs and Slots declarations to override default denial (requires store assertion to publish)
-          # plugs: ./plug-declaration.json
-          # slots: ./slot-declaration.json

--- a/OLD_VERSION
+++ b/OLD_VERSION
@@ -1,1 +1,0 @@
-OLD_VERSION=0.0.1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: discord
 base: core22
-adopt-info: discord
+version: 0.0.36
 summary: Chat for Communities and Friends
 description: |
   Discord is the easiest way to communicate over voice, video and text.
@@ -50,12 +50,9 @@ parts:
     plugin: nil
     override-build: |
       craftctl default
-      DEB_API="https://discord.com/api/download?platform=linux&format=deb"
-      DEB_URL=$(curl -w "%{url_effective}\n" -I -L -s -S "${DEB_API}" -o /dev/null)
-      curl -o discord.deb $DEB_URL
+      curl -o discord.deb "https://dl.discordapp.net/apps/linux/${SNAPCRAFT_PROJECT_VERSION}/discord-${SNAPCRAFT_PROJECT_VERSION}.deb"
       dpkg-deb -xv discord.deb $CRAFT_PART_INSTALL/
-      VERSION=$(echo "${DEB_URL}" | cut -d'/' -f6)
-      craftctl set version=$(echo $VERSION)
+
       rm $CRAFT_PART_INSTALL/usr/share/discord/chrome-sandbox
       # Correct path to icon.
       sed -i 's|Icon=discord|Icon=/usr/share/discord/discord\.png|' ${CRAFT_PART_INSTALL}/usr/share/discord/discord.desktop


### PR DESCRIPTION
This PR lifts the latest set of workflows from https://github.com/snapcrafters/signal-desktop.

This includes adding an action to sync the release to the latest Discord release. As part of this, the `version` is now set statically in the `snapcraft.yaml` to enable the automation.