### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,9 +6,7 @@ description: |
 
   Snaps are confined, as such Discord may be unable to perform some of the tasks it typically does when unconfined. This may result in the system log getting spammed with apparmor errors. Granting access to the system-observe interface when in the snap will enable the features, and thus reduce the logging.
 
-  ```
-  snap connect discord:system-observe
-  ```
+    snap connect discord:system-observe
 
   **Authors**
 


### PR DESCRIPTION
Apparently, the snap store doesn't fully support using three backticks for code blocks