### PR TITLE
fix: workaround core24 window sharing bug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ license: Proprietary
 icon: snap/discord.png
 version: 0.0.68
 
-base: core24
+base: core22  # Reverted to core22 as a temporary workaround for https://github.com/snapcrafters/discord/issues/233
 grade: stable
 confinement: strict
 compression: lzo
@@ -28,8 +28,8 @@ compression: lzo
 assumes:
   - snapd2.54
 
-platforms:
-  amd64:
+architectures:
+  - amd64
 
 parts:
   launcher:


### PR DESCRIPTION
This reverts to core22 until we know why core24 isn't properly sharing windows on x11.

Workaround for #233 