### PR TITLE
Do not change desktop file name

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ confinement: strict
 compression: lzo
 
 assumes:
-  - snapd2.54
+  - snapd2.66
 
 architectures:
   - amd64
@@ -58,6 +58,9 @@ parts:
       - -usr/bin/xdg-open
 
 plugs:
+  desktop:
+    desktop-file-ids: [discord]
+
   shmem:
     interface: shared-memory
     private: true


### PR DESCRIPTION
By default snap creates desktop entries in the format of '{SNAP_NAME}_{APP_NAME}.desktop' which breaks the way KDE associates windows with their desktop file.

This commit fixes the app icon in KDE's provided window decorations.