### PR TITLE
snap: patch desktop file name

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,7 +65,7 @@ parts:
     plugin: nil
     override-build: |
       pip install asarPy
-      python3 $CRAFT_PART_SRC_WORK/patch-desktop-filename.py $CRAFT_STAGE/usr/share/discord/resources/app.asar
+      python3 "${CRAFT_PART_SRC_WORK}/patch-desktop-filename.py" "${CRAFT_STAGE}/usr/share/discord/resources/app.asar"
 
 plugs:
   shmem:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,11 +61,12 @@ parts:
   patch-desktop-file-name:
     after: [discord]
     source: https://github.com/snapcrafters/patch-desktop-file-name.git
+    source-branch: uv-standalone
     source-subdir: electron
     plugin: nil
+    build-snaps: [astral-uv]
     override-build: |
-      pip install asarPy
-      python3 "${CRAFT_PART_SRC_WORK}/patch-desktop-filename.py" "${CRAFT_STAGE}/usr/share/discord/resources/app.asar"
+      ./patch_desktop_file_name.py "${CRAFT_STAGE}/usr/share/discord/resources/app.asar"
 
 plugs:
   shmem:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,13 +60,12 @@ parts:
   # Needed for setting the proper desktop file name in the electron apps
   patch-desktop-file-name:
     after: [discord]
-    source: https://github.com/snapcrafters/patch-desktop-file-name.git
-    source-branch: uv-standalone
-    source-subdir: electron
     plugin: nil
     build-snaps: [astral-uv]
     override-build: |
-      ./patch_desktop_file_name.py "${CRAFT_STAGE}/usr/share/discord/resources/app.asar"
+      uv run \
+        https://raw.githubusercontent.com/snapcrafters/patch-desktop-file-name/refs/heads/uv-standalone/electron/patch-desktop-filename.py \
+        "${CRAFT_STAGE}/usr/share/discord/resources/app.asar"
 
 plugs:
   shmem:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,6 +57,16 @@ parts:
       - -usr/share/discord/chrome-sandbox
       - -usr/bin/xdg-open
 
+  # Needed for setting the proper desktop file name in the electron apps
+  patch-desktop-file-name:
+    after: [discord]
+    source: https://github.com/snapcrafters/patch-desktop-file-name.git
+    source-subdir: electron
+    plugin: nil
+    override-build: |
+      pip install asarPy --break-system-packages
+      python3 $CRAFT_PART_SRC_WORK/patch-desktop-filename.py $CRAFT_STAGE/usr/share/discord/resources/app.asar
+
 plugs:
   shmem:
     interface: shared-memory

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
     build-snaps: [astral-uv]
     override-build: |
       uv run \
-        https://raw.githubusercontent.com/snapcrafters/patch-desktop-file-name/refs/heads/uv-standalone/electron/patch-desktop-filename.py \
+        https://raw.githubusercontent.com/snapcrafters/patch-desktop-file-name/refs/heads/main/electron/patch-desktop-filename.py \
         "${CRAFT_STAGE}/usr/share/discord/resources/app.asar"
 
 plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
     source-subdir: electron
     plugin: nil
     override-build: |
-      pip install asarPy --break-system-packages
+      pip install asarPy
       python3 $CRAFT_PART_SRC_WORK/patch-desktop-filename.py $CRAFT_STAGE/usr/share/discord/resources/app.asar
 
 plugs:


### PR DESCRIPTION
This an alternative and simple PR for #256 

@AKoskovich We're already modifying the original binary a bit. So, I don't think that's really an issue.

Implemented in [Element Desktop](https://github.com/kenvandine/element-desktop/blob/main/snap/snapcraft.yaml#L46-L54), [WebCord](https://github.com/soumyaDghosh/webcord-snap/blob/main/snap/snapcraft.yaml#L39-L47) also.