### PR TITLE
fix: gate version sync and build on update server propagation

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -25,4 +25,15 @@ jobs:
             DEB_API="https://discord.com/api/download?platform=linux&format=deb"
             DEB_URL=$(curl -w "%{url_effective}\n" -I -L -s -S "${DEB_API}" -o /dev/null)
             VERSION=$(echo "${DEB_URL}" | cut -d'/' -f6)
+
+            # Verify the Discord update server is already serving this version.
+            # The bootstrapper fetches the real app from updates.discord.com at
+            # build time — if the server hasn't propagated yet we'd build a snap
+            # labelled $VERSION but containing the previous release.
+            UPDATE_SERVER_VERSION=$(curl -s "https://discord.com/api/updates/stable?platform=linux" | jq -r '.name')
+            if [ "$UPDATE_SERVER_VERSION" != "$VERSION" ]; then
+              echo "Skipping: .deb is $VERSION but update server reports $UPDATE_SERVER_VERSION — not yet propagated."
+              exit 0
+            fi
+
             sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,6 +58,15 @@ parts:
       "${CRAFT_PART_INSTALL}/usr/share/discord/updater_bootstrap" --no-zenity "${CRAFT_PART_BUILD}/download" stable https://updates.discord.com
       cp -r ${CRAFT_PART_BUILD}/download/app-*/* "${CRAFT_PART_INSTALL}/usr/share/discord/"
 
+      # Assert that the bootstrapper downloaded the version we expect.
+      # If the update server lagged at build time this will be the previous
+      # release — fail fast rather than publishing a mislabelled snap.
+      DOWNLOADED_VERSION=$(jq -r '.version' "${CRAFT_PART_INSTALL}/usr/share/discord/resources/build_info.json")
+      if [ "$DOWNLOADED_VERSION" != "$SNAPCRAFT_PROJECT_VERSION" ]; then
+        echo "ERROR: bootstrapper downloaded Discord $DOWNLOADED_VERSION but snap version is $SNAPCRAFT_PROJECT_VERSION"
+        exit 1
+      fi
+
       # The bootstrapper downloads modules into versioned directories
       # (e.g. modules/discord_desktop_core-1/discord_desktop_core/). At runtime,
       # Discord would normally install these from bootstrap zip files into a


### PR DESCRIPTION
## Problem

When Discord publishes a new release, the `.deb` on `dl.discordapp.net` and the update server at `updates.discord.com` don't always propagate in sync. The build process runs `updater_bootstrap` at build time to fetch the real Electron app from the update server — if the server hasn't caught up yet, the bootstrapper silently downloads the previous release.

This produces a snap labelled e.g. `1.0.139` that actually contains the `1.0.138` client. Reported in #329.

## Fix

Two changes, in separate commits:

### 1. CI: gate version sync on update server propagation (`sync-version-with-upstream.yml`)

Before updating `snapcraft.yaml`, the workflow now queries `https://discord.com/api/updates/stable?platform=linux` and compares the reported version against the `.deb` version. If they don't match, the workflow exits 0 (soft skip) — no version bump is written, and the scheduled job will retry the next day once the server has propagated.

### 2. Snap: assert downloaded version at build time (`snapcraft.yaml`)

After `updater_bootstrap` copies the app into the install directory, `build_info.json` is read and the `version` field is compared against `$SNAPCRAFT_PROJECT_VERSION`. If they don't match the build fails immediately with a clear error, rather than silently publishing a mislabelled snap. This acts as defence-in-depth in case the CI gate is bypassed or a version is bumped manually.

## Testing

The CI gate can be tested by temporarily pointing the version check at a version that hasn't shipped yet. The build-time assertion will fire in the normal build workflow if the update server ever lags at the moment a build is triggered.