### PR TITLE
fix: gate version sync on CDN availability and revert to 1.0.139

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -26,13 +26,16 @@ jobs:
             DEB_URL=$(curl -w "%{url_effective}\n" -I -L -s -S "${DEB_API}" -o /dev/null)
             VERSION=$(echo "${DEB_URL}" | cut -d'/' -f6)
 
-            # Verify the Discord update server is already serving this version.
-            # The bootstrapper fetches the real app from updates.discord.com at
-            # build time. If the server has not propagated yet, we would build a
-            # snap labelled $VERSION but containing the previous release.
-            UPDATE_SERVER_VERSION=$(curl -s "https://discord.com/api/updates/stable?platform=linux" | jq -r '.name')
-            if [ "$UPDATE_SERVER_VERSION" != "$VERSION" ]; then
-              echo "Skipping: .deb is $VERSION but update server reports $UPDATE_SERVER_VERSION - not yet propagated."
+            # Verify the versioned tarball is present on Discord's CDN before
+            # bumping the version. The bootstrapper fetches the real app from
+            # dl.discordapp.net at build time, so this directly confirms the
+            # artifact the build needs is available. The discord.com/api/updates
+            # endpoint is not sufficient - it reflects a separate backend that
+            # can propagate ahead of the CDN.
+            CDN_URL="https://dl.discordapp.net/apps/linux/${VERSION}/discord-${VERSION}.tar.gz"
+            CDN_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -I "${CDN_URL}")
+            if [ "${CDN_STATUS}" != "200" ]; then
+              echo "Skipping: discord-${VERSION}.tar.gz not yet available on CDN (HTTP ${CDN_STATUS})."
               exit 0
             fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ issues: https://github.com//snapcrafters/discord/issues
 source-code: https://github.com//snapcrafters/discord
 license: Proprietary
 icon: snap/discord.png
-version: 1.0.140
+version: 1.0.139
 
 base: core22 # Reverted to core22 as a temporary workaround for https://github.com/snapcrafters/discord/issues/233
 grade: stable


### PR DESCRIPTION
## Problem

When Discord publishes a new release, the `discord.com/api/updates/stable` API endpoint and the actual CDN (`dl.discordapp.net`) propagate independently. The previous attempt at a fix (#331) gated the version sync on the API endpoint, but this proved insufficient: `1.0.140` was bumped based on the API reporting the new version, but the build [subsequently failed](https://github.com/snapcrafters/discord/actions/runs/26566175927/job/78263413681) because the bootstrapper could not fetch `1.0.140` from the CDN at build time.

## Fix

Three commits:

### 1. Revert to 1.0.139

`1.0.140` was bumped prematurely. `1.0.139` is the last known-good version.

### 2. Gate version sync on CDN availability (`sync-version-with-upstream.yml`)

Replace the `api/updates/stable` check with a direct `HEAD` request against the versioned tarball on `dl.discordapp.net`:

```
https://dl.discordapp.net/apps/linux/{VERSION}/discord-{VERSION}.tar.gz
```

A 200 response confirms the exact artifact the bootstrapper will fetch is present on the CDN. If the check fails, the workflow exits 0 (soft skip) and retries on the next daily schedule.

### 3. Assert downloaded version at build time (`snapcraft.yaml`)

Already merged into `candidate` via the previous attempt. Kept here as it is the correct defence-in-depth — if the CDN gate is ever bypassed, the build fails immediately rather than publishing a mislabelled snap.

Fixes #329