### PR TITLE
fix: source Discord bootstrapper from tarball

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -22,20 +22,44 @@ jobs:
         with:
           token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
+            set -euo pipefail
+
             DEB_API="https://discord.com/api/download?platform=linux&format=deb"
             DEB_URL=$(curl -w "%{url_effective}\n" -I -L -s -S "${DEB_API}" -o /dev/null)
             VERSION=$(echo "${DEB_URL}" | cut -d'/' -f6)
 
-            # Verify the versioned tarball is present on Discord's CDN before
-            # bumping the version. The bootstrapper fetches the real app from
-            # dl.discordapp.net at build time, so this directly confirms the
-            # artifact the build needs is available. The discord.com/api/updates
-            # endpoint is not sufficient - it reflects a separate backend that
-            # can propagate ahead of the CDN.
-            CDN_URL="https://dl.discordapp.net/apps/linux/${VERSION}/discord-${VERSION}.tar.gz"
-            CDN_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -I "${CDN_URL}")
-            if [ "${CDN_STATUS}" != "200" ]; then
-              echo "Skipping: discord-${VERSION}.tar.gz not yet available on CDN (HTTP ${CDN_STATUS})."
+            # Verify the same updater path used by snapcraft.yaml before
+            # bumping the snap version. The versioned .deb/.tar.gz can appear
+            # before updates.discord.com serves the matching app bundle.
+            CHECK_DIR=$(mktemp -d)
+            trap 'rm -rf "${CHECK_DIR}"' EXIT
+
+            TARBALL_URL="https://dl.discordapp.net/apps/linux/${VERSION}/discord-${VERSION}.tar.gz"
+            if ! curl -L -f -s -S "${TARBALL_URL}" -o "${CHECK_DIR}/discord.tar.gz"; then
+              echo "Skipping: discord-${VERSION}.tar.gz is not available."
+              exit 0
+            fi
+            if ! tar -xzf "${CHECK_DIR}/discord.tar.gz" -C "${CHECK_DIR}"; then
+              echo "Skipping: discord-${VERSION}.tar.gz could not be extracted."
+              exit 0
+            fi
+
+            DOWNLOAD_DIR="${CHECK_DIR}/download"
+            mkdir -p "${DOWNLOAD_DIR}"
+            if ! "${CHECK_DIR}/Discord/updater_bootstrap" --no-zenity "${DOWNLOAD_DIR}" stable https://updates.discord.com; then
+              echo "Skipping: updater bootstrap failed."
+              exit 0
+            fi
+
+            BUILD_INFO=$(find "${DOWNLOAD_DIR}" -path '*/resources/build_info.json' -print -quit)
+            if [ -z "${BUILD_INFO}" ]; then
+              echo "Skipping: updater bootstrap did not produce build_info.json."
+              exit 0
+            fi
+
+            DOWNLOADED_VERSION=$(jq -r '.version' "${BUILD_INFO}")
+            if [ "${DOWNLOADED_VERSION}" != "${VERSION}" ]; then
+              echo "Skipping: upstream reports ${VERSION} but updater bootstrap downloaded ${DOWNLOADED_VERSION}."
               exit 0
             fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,10 +43,12 @@ parts:
     plugin: dump
     source: https://dl.discordapp.net/apps/linux/${SNAPCRAFT_PROJECT_VERSION}/discord-${SNAPCRAFT_PROJECT_VERSION}.tar.gz
     source-type: tar
-    organize:
-      Discord: usr/share/discord
     override-build: |
       craftctl default
+
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/discord"
+      mv "${CRAFT_PART_INSTALL}/Discord"/* "${CRAFT_PART_INSTALL}/usr/share/discord/"
+      rmdir "${CRAFT_PART_INSTALL}/Discord"
 
       # Fix the .desktop file icon path for the snap.
       sed -i 's|Icon=discord|Icon=/usr/share/discord/discord\.png|' ${CRAFT_PART_INSTALL}/usr/share/discord/discord.desktop

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,18 +41,20 @@ parts:
 
   discord:
     plugin: dump
-    source: https://dl.discordapp.net/apps/linux/${SNAPCRAFT_PROJECT_VERSION}/discord-${SNAPCRAFT_PROJECT_VERSION}.deb
-    source-type: deb
+    source: https://dl.discordapp.net/apps/linux/${SNAPCRAFT_PROJECT_VERSION}/discord-${SNAPCRAFT_PROJECT_VERSION}.tar.gz
+    source-type: tar
+    organize:
+      Discord: usr/share/discord
     override-build: |
       craftctl default
 
       # Fix the .desktop file icon path for the snap.
       sed -i 's|Icon=discord|Icon=/usr/share/discord/discord\.png|' ${CRAFT_PART_INSTALL}/usr/share/discord/discord.desktop
 
-      # The upstream .deb doesn't contain the actual Discord app — only a
-      # bootstrapper (updater_bootstrap) that normally downloads Discord into
-      # the user's home directory at runtime. Since snap confinement prevents
-      # that, we run the bootstrapper at build time instead.
+      # The upstream tarball contains a bootstrapper (updater_bootstrap) that
+      # normally downloads Discord into the user's home directory at runtime.
+      # Since snap confinement prevents that, we run the bootstrapper at build
+      # time instead.
       
       mkdir -p "${CRAFT_PART_BUILD}/download"
       "${CRAFT_PART_INSTALL}/usr/share/discord/updater_bootstrap" --no-zenity "${CRAFT_PART_BUILD}/download" stable https://updates.discord.com


### PR DESCRIPTION
## Summary
- switch the Discord part source from the versioned `.deb` to the versioned `.tar.gz`
- install the extracted tarball payload into `/usr/share/discord` explicitly in `override-build`
- replace the `sync-version` CDN HEAD check with the same updater-bootstrap version check enforced in `snapcraft.yaml`
- keep the build-time `build_info.json` assertion as defence in depth

## Notes
The upstream versioned tarball is still only the small bootstrapper payload, not the full app bundle. This PR makes the bump-time gate and build-time gate use the same predicate: run `updater_bootstrap`, read the downloaded app's `resources/build_info.json`, and require that version to match the proposed snap version.

A local probe before updating the PR showed upstream reporting `1.0.141` while `updater_bootstrap` still installed `app-1.0.140`, so this should prevent the bot from committing that bump until the updater backend catches up.

## Testing
- Parsed `.github/workflows/sync-version-with-upstream.yml` and `snap/snapcraft.yaml` with Python/PyYAML
- Extracted the embedded `update-script` and checked it with `bash -n`
- Ran the embedded `update-script` locally; it exited successfully without modifying `snapcraft.yaml` and printed: `Skipping: upstream reports 1.0.141 but updater bootstrap downloaded 1.0.140.`
- Simulated the tarball install move locally and verified `usr/share/discord/discord.desktop` and `usr/share/discord/updater_bootstrap` land in the expected path
- `snapcraft` is not installed in this runner, so no local snap build was run
