### PR TITLE
ci: gate version sync on updater bootstrap

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -22,20 +22,41 @@ jobs:
         with:
           token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
+            set -euo pipefail
+
             DEB_API="https://discord.com/api/download?platform=linux&format=deb"
             DEB_URL=$(curl -w "%{url_effective}\n" -I -L -s -S "${DEB_API}" -o /dev/null)
             VERSION=$(echo "${DEB_URL}" | cut -d'/' -f6)
 
-            # Verify the versioned tarball is present on Discord's CDN before
-            # bumping the version. The bootstrapper fetches the real app from
-            # dl.discordapp.net at build time, so this directly confirms the
-            # artifact the build needs is available. The discord.com/api/updates
-            # endpoint is not sufficient - it reflects a separate backend that
-            # can propagate ahead of the CDN.
-            CDN_URL="https://dl.discordapp.net/apps/linux/${VERSION}/discord-${VERSION}.tar.gz"
-            CDN_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -I "${CDN_URL}")
-            if [ "${CDN_STATUS}" != "200" ]; then
-              echo "Skipping: discord-${VERSION}.tar.gz not yet available on CDN (HTTP ${CDN_STATUS})."
+            # Verify the same updater path used by snapcraft.yaml before
+            # bumping the snap version. The versioned .deb can appear before
+            # updates.discord.com serves the matching app bundle.
+            CHECK_DIR=$(mktemp -d)
+            trap 'rm -rf "${CHECK_DIR}"' EXIT
+
+            if ! curl -L -f -s -S "${DEB_URL}" -o "${CHECK_DIR}/discord.deb"; then
+              echo "Skipping: discord-${VERSION}.deb is not available."
+              exit 0
+            fi
+
+            dpkg-deb -x "${CHECK_DIR}/discord.deb" "${CHECK_DIR}/deb"
+
+            DOWNLOAD_DIR="${CHECK_DIR}/download"
+            mkdir -p "${DOWNLOAD_DIR}"
+            if ! "${CHECK_DIR}/deb/usr/share/discord/updater_bootstrap" --no-zenity "${DOWNLOAD_DIR}" stable https://updates.discord.com; then
+              echo "Skipping: updater bootstrap failed."
+              exit 0
+            fi
+
+            BUILD_INFO=$(find "${DOWNLOAD_DIR}" -path '*/resources/build_info.json' -print -quit)
+            if [ -z "${BUILD_INFO}" ]; then
+              echo "Skipping: updater bootstrap did not produce build_info.json."
+              exit 0
+            fi
+
+            DOWNLOADED_VERSION=$(jq -r '.version' "${BUILD_INFO}")
+            if [ "${DOWNLOADED_VERSION}" != "${VERSION}" ]; then
+              echo "Skipping: upstream reports ${VERSION} but updater bootstrap downloaded ${DOWNLOADED_VERSION}."
               exit 0
             fi
 

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -41,23 +41,25 @@ jobs:
 
             dpkg-deb -x "${CHECK_DIR}/discord.deb" "${CHECK_DIR}/deb"
 
+            MODULE_LOCK="${CHECK_DIR}/discord-updater-modules.json"
+            if ! python3 snap/local/bin/generate-discord-updater-manifest \
+              --version "${VERSION}" \
+              lock-modules \
+              --output "${MODULE_LOCK}"; then
+              echo "Skipping: Discord ${VERSION} updater manifest is not ready."
+              exit 0
+            fi
+
             DOWNLOAD_DIR="${CHECK_DIR}/download"
-            mkdir -p "${DOWNLOAD_DIR}"
-            if ! "${CHECK_DIR}/deb/usr/share/discord/updater_bootstrap" --no-zenity "${DOWNLOAD_DIR}" stable https://updates.discord.com; then
-              echo "Skipping: updater bootstrap failed."
+            if ! python3 snap/local/bin/generate-discord-updater-manifest \
+              --version "${VERSION}" \
+              bootstrap \
+              --bootstrapper "${CHECK_DIR}/deb/usr/share/discord/updater_bootstrap" \
+              --root "${DOWNLOAD_DIR}" \
+              --module-lock "${MODULE_LOCK}"; then
+              echo "Skipping: Discord ${VERSION} distro packages are not ready."
               exit 0
             fi
 
-            BUILD_INFO=$(find "${DOWNLOAD_DIR}" -path '*/resources/build_info.json' -print -quit)
-            if [ -z "${BUILD_INFO}" ]; then
-              echo "Skipping: updater bootstrap did not produce build_info.json."
-              exit 0
-            fi
-
-            DOWNLOADED_VERSION=$(jq -r '.version' "${BUILD_INFO}")
-            if [ "${DOWNLOADED_VERSION}" != "${VERSION}" ]; then
-              echo "Skipping: upstream reports ${VERSION} but updater bootstrap downloaded ${DOWNLOADED_VERSION}."
-              exit 0
-            fi
-
+            cp "${MODULE_LOCK}" snap/local/discord-updater-modules.json
             sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml

--- a/snap/local/bin/generate-discord-updater-manifest
+++ b/snap/local/bin/generate-discord-updater-manifest
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Generate version-pinned Discord updater manifests.
+
+Discord publishes the latest .deb before updates.discord.com always serves the
+same version from its `latest` manifest. The sync workflow records the module
+list from Discord's matching updater manifest, and the snap build uses that
+lock to generate a version-pinned manifest from versioned .distro URLs. The
+script serves the pinned manifest to updater_bootstrap locally, then verifies
+the downloaded app version and modules before the snap consumes the payload.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+UPDATER_MANIFEST_URL = (
+    "https://updates.discord.com/distributions/app/manifests/latest"
+    "?channel={channel}&platform=linux&arch=x64"
+)
+USER_AGENT = "snapcrafters-discord-updater-manifest"
+
+
+def parse_version(version: str) -> list[int]:
+    """Return Discord's dotted version string as updater manifest integers."""
+    parts = version.split(".")
+    if len(parts) != 3:
+        raise ValueError(f"expected MAJOR.MINOR.PATCH version, got {version!r}")
+    return [int(part) for part in parts]
+
+
+def distro_package_url(version: str, channel: str, path: str) -> str:
+    """Return the versioned .distro URL for an app or module artifact."""
+    return (
+        f"https://stable.dl2.discordapp.net/distro/app/{channel}/linux/x64/"
+        f"{version}/{path}"
+    )
+
+
+def sha256_url(url: str) -> str:
+    """Stream an artifact from Discord and return its SHA256 digest."""
+    digest = hashlib.sha256()
+    try:
+        request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+        with urllib.request.urlopen(request) as response:
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"{url} returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"failed to fetch {url}: {exc.reason}") from exc
+    return digest.hexdigest()
+
+
+def fetch_json(url: str) -> dict:
+    """Fetch a JSON object from a URL."""
+    try:
+        request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+        with urllib.request.urlopen(request) as response:
+            data = json.load(response)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"{url} returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"failed to fetch {url}: {exc.reason}") from exc
+
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{url} did not return a JSON object")
+    return data
+
+
+def matching_upstream_manifest(version: str, channel: str) -> dict:
+    """Fetch Discord's updater manifest and require it to match the version."""
+    url = UPDATER_MANIFEST_URL.format(channel=channel)
+    manifest = fetch_json(url)
+    actual_version = ".".join(
+        str(part) for part in manifest.get("full", {}).get("host_version", [])
+    )
+    if actual_version != version:
+        raise RuntimeError(
+            f"updater manifest is for Discord {actual_version}, not {version}"
+        )
+    return manifest
+
+
+def write_module_lock(version: str, channel: str, output: Path) -> None:
+    """Write the module list from Discord's matching updater manifest."""
+    manifest = matching_upstream_manifest(version, channel)
+    modules = {
+        name: data.get("full", {}).get("module_version")
+        for name, data in sorted(manifest.get("modules", {}).items())
+    }
+    if not modules:
+        raise RuntimeError("updater manifest does not list any modules")
+    if not all(isinstance(module_version, int) for module_version in modules.values()):
+        raise RuntimeError("updater manifest contains a module without module_version")
+
+    lock = {
+        "version": version,
+        "channel": channel,
+        "modules": modules,
+        "required_modules": sorted(manifest.get("required_modules", [])),
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(lock, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def locked_module_versions(path: Path, version: str, channel: str) -> dict[str, int]:
+    """Read and validate module versions from the committed lock file."""
+    with path.open(encoding="utf-8") as file:
+        lock = json.load(file)
+
+    if lock.get("version") != version:
+        raise RuntimeError(f"{path} is for Discord {lock.get('version')}, not {version}")
+    if lock.get("channel") != channel:
+        raise RuntimeError(f"{path} is for {lock.get('channel')}, not {channel}")
+
+    modules = lock.get("modules")
+    if not isinstance(modules, dict) or not all(
+        isinstance(name, str) and isinstance(module_version, int)
+        for name, module_version in modules.items()
+    ):
+        raise RuntimeError(f"{path} does not contain valid module versions")
+    if not modules:
+        raise RuntimeError(f"{path} does not list any modules")
+    return modules
+
+
+def build_manifest(version: str, channel: str, modules: dict[str, int]) -> dict:
+    """Generate a minimal updater manifest pinned to one Discord version."""
+    version_parts = parse_version(version)
+    app_url = distro_package_url(version, channel, "full.distro")
+    module_manifests = {}
+    for name, module_version in modules.items():
+        module_url = distro_package_url(
+            version, channel, f"{name}/{module_version}/full.distro"
+        )
+        module_manifests[name] = {
+            "full": {
+                "host_version": version_parts,
+                "module_version": module_version,
+                "package_sha256": sha256_url(module_url),
+                "url": module_url,
+            },
+            "deltas": [],
+        }
+
+    return {
+        "full": {
+            "host_version": version_parts,
+            "package_sha256": sha256_url(app_url),
+            "url": app_url,
+        },
+        "deltas": [],
+        "modules": module_manifests,
+        "required_modules": sorted(modules),
+        "metadata_version": int(time.time()),
+        "required_update": True,
+    }
+
+
+class ManifestHandler(BaseHTTPRequestHandler):
+    """HTTP handler that serves the generated manifest to updater_bootstrap."""
+
+    manifest: bytes
+
+    def do_GET(self) -> None:  # noqa: N802 - inherited API
+        """Serve the generated manifest at the path updater_bootstrap requests."""
+        if self.path.startswith("/distributions/app/manifests/latest"):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(self.manifest)))
+            self.end_headers()
+            self.wfile.write(self.manifest)
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, _format: str, *args: object) -> None:
+        """Silence the local HTTP server's request logging in CI output."""
+        return
+
+
+def serve_manifest(manifest_path: Path) -> ThreadingHTTPServer:
+    """Start a localhost manifest server and return the running server."""
+    ManifestHandler.manifest = manifest_path.read_bytes()
+    server = ThreadingHTTPServer(("127.0.0.1", 0), ManifestHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def downloaded_version(root: Path) -> str | None:
+    """Read the installed app version from Discord's build_info.json."""
+    for build_info in root.glob("app-*/resources/build_info.json"):
+        with build_info.open(encoding="utf-8") as file:
+            data = json.load(file)
+        return data.get("version")
+    return None
+
+
+def missing_modules(root: Path, modules: list[str]) -> list[str]:
+    """Return expected modules that updater_bootstrap did not install."""
+    app_path = next((path for path in root.glob("app-*") if path.is_dir()), None)
+    if app_path is None:
+        return modules
+
+    modules_dir = app_path / "modules"
+    missing = []
+    for name in modules:
+        if not any(modules_dir.glob(f"{name}-*")):
+            missing.append(name)
+
+    return missing
+
+
+def bootstrap(
+    version: str,
+    channel: str,
+    bootstrapper: Path,
+    root: Path,
+    module_lock: Path,
+) -> int:
+    """Run updater_bootstrap against a generated manifest and validate output."""
+    modules = locked_module_versions(module_lock, version, channel)
+    root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        manifest_path = Path(tmp) / "manifest.json"
+        manifest = build_manifest(version, channel, modules)
+        manifest_path.write_text(
+            json.dumps(manifest, separators=(",", ":")), encoding="utf-8"
+        )
+        server = serve_manifest(manifest_path)
+        try:
+            host, port = server.server_address
+            repository_url = f"http://{host}:{port}/"
+            command = [
+                str(bootstrapper),
+                "--no-zenity",
+                str(root),
+                channel,
+                repository_url,
+            ]
+            result = subprocess.run(command, check=False)
+        finally:
+            server.shutdown()
+
+    if result.returncode != 0:
+        return result.returncode
+
+    actual_version = downloaded_version(root)
+    if actual_version != version:
+        print(
+            f"ERROR: updater bootstrap downloaded Discord {actual_version} "
+            f"but requested {version}",
+            file=sys.stderr,
+        )
+        return 1
+
+    missing_locked_modules = missing_modules(root, sorted(modules))
+    if missing_locked_modules:
+        print(
+            "ERROR: updater bootstrap did not download locked modules: "
+            + ", ".join(missing_locked_modules),
+            file=sys.stderr,
+        )
+        return 1
+
+    app_path = next((path for path in root.glob("app-*") if path.is_dir()), None)
+    bootstrap_manifest = (
+        app_path / "resources/bootstrap/manifest.json" if app_path is not None else None
+    )
+    if bootstrap_manifest is not None and bootstrap_manifest.exists():
+        with bootstrap_manifest.open(encoding="utf-8") as file:
+            required_modules = json.load(file)
+
+        if not isinstance(required_modules, dict):
+            raise RuntimeError(
+                f"unexpected bootstrap manifest shape: {bootstrap_manifest}"
+            )
+
+        missing_required_modules = missing_modules(root, sorted(required_modules))
+        if missing_required_modules:
+            print(
+                "ERROR: updater bootstrap did not download required modules: "
+                + ", ".join(missing_required_modules),
+                file=sys.stderr,
+            )
+            return 1
+
+    return 0
+
+
+def main() -> int:
+    """Parse CLI arguments and run the requested manifest command."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--channel", default="stable")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    lock_parser = subparsers.add_parser("lock-modules")
+    lock_parser.add_argument("--output", required=True, type=Path)
+
+    bootstrap_parser = subparsers.add_parser("bootstrap")
+    bootstrap_parser.add_argument("--bootstrapper", required=True, type=Path)
+    bootstrap_parser.add_argument("--root", required=True, type=Path)
+    bootstrap_parser.add_argument("--module-lock", required=True, type=Path)
+
+    args = parser.parse_args()
+
+    try:
+        if args.command == "lock-modules":
+            write_module_lock(args.version, args.channel, args.output)
+            return 0
+
+        if args.command == "bootstrap":
+            return bootstrap(
+                args.version,
+                args.channel,
+                args.bootstrapper,
+                args.root,
+                args.module_lock,
+            )
+    except Exception as exc:  # noqa: BLE001 - keep CI failure readable.
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/snap/local/discord-updater-modules.json
+++ b/snap/local/discord-updater-modules.json
@@ -1,0 +1,25 @@
+{
+  "channel": "stable",
+  "modules": {
+    "discord_cloudsync": 1,
+    "discord_desktop_core": 1,
+    "discord_dispatch": 1,
+    "discord_erlpack": 1,
+    "discord_game_utils": 1,
+    "discord_krisp": 1,
+    "discord_modules": 1,
+    "discord_rpc": 1,
+    "discord_spellcheck": 1,
+    "discord_utils": 1,
+    "discord_voice": 1,
+    "discord_zstd": 1
+  },
+  "required_modules": [
+    "discord_desktop_core",
+    "discord_erlpack",
+    "discord_spellcheck",
+    "discord_utils",
+    "discord_voice"
+  ],
+  "version": "1.0.141"
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,20 +52,14 @@ parts:
       # The upstream .deb doesn't contain the actual Discord app — only a
       # bootstrapper (updater_bootstrap) that normally downloads Discord into
       # the user's home directory at runtime. Since snap confinement prevents
-      # that, we run the bootstrapper at build time instead.
-      
-      mkdir -p "${CRAFT_PART_BUILD}/download"
-      "${CRAFT_PART_INSTALL}/usr/share/discord/updater_bootstrap" --no-zenity "${CRAFT_PART_BUILD}/download" stable https://updates.discord.com
+      # that, we run the bootstrapper at build time against a pinned manifest.
+      python3 "${CRAFT_PROJECT_DIR}/snap/local/bin/generate-discord-updater-manifest" \
+        --version "${SNAPCRAFT_PROJECT_VERSION}" \
+        bootstrap \
+        --bootstrapper "${CRAFT_PART_INSTALL}/usr/share/discord/updater_bootstrap" \
+        --root "${CRAFT_PART_BUILD}/download" \
+        --module-lock "${CRAFT_PROJECT_DIR}/snap/local/discord-updater-modules.json"
       cp -r ${CRAFT_PART_BUILD}/download/app-*/* "${CRAFT_PART_INSTALL}/usr/share/discord/"
-
-      # Assert that the bootstrapper downloaded the version we expect.
-      # If the update server lagged at build time this will be the previous
-      # release. Fail fast rather than publishing a mislabelled snap.
-      DOWNLOADED_VERSION=$(jq -r '.version' "${CRAFT_PART_INSTALL}/usr/share/discord/resources/build_info.json")
-      if [ "$DOWNLOADED_VERSION" != "$SNAPCRAFT_PROJECT_VERSION" ]; then
-        echo "ERROR: bootstrapper downloaded Discord $DOWNLOADED_VERSION but snap version is $SNAPCRAFT_PROJECT_VERSION"
-        exit 1
-      fi
 
       # The bootstrapper downloads modules into versioned directories
       # (e.g. modules/discord_desktop_core-1/discord_desktop_core/). At runtime,
@@ -89,6 +83,7 @@ parts:
       mv /tmp/build_info.json "${CRAFT_PART_INSTALL}/usr/share/discord/resources/build_info.json"
     build-packages:
       - jq
+      - python3
     stage-packages:
       - libatomic1
       - libc++1


### PR DESCRIPTION
## Summary
- keep the Discord snap source on the versioned `.deb`
- add one local Python helper with only the two workflow paths we use: lock upstream modules, then bootstrap from the committed lock
- lock module names and module package versions from Discord's matching upstream updater manifest during sync-version, then use that lock during snap builds
- use the helper in both `sync-version` and `snapcraft.yaml` so builds no longer depend on `updates.discord.com/.../latest` cache propagation at build time

## Notes
Discord publishes the versioned `.deb` and `.distro` payloads before `updates.discord.com/distributions/app/manifests/latest` is consistently updated across Cloudflare. The previous sync gate mirrored the build-time updater path, but the current `candidate` branch can still fail because the build itself calls the cached `latest` manifest.

The helper uses Discord's official updater manifest as the source of truth for the complete module set, but only when that manifest reports the same version as the `.deb`. The sync workflow writes that module set and each upstream module package version to `snap/local/discord-updater-modules.json`, making module additions/removals visible in the version bump diff without hard-coding module package paths.

The snap build uses the committed lock to generate a version-pinned local manifest, serves it on `127.0.0.1` for `updater_bootstrap`, then verifies the downloaded `resources/build_info.json` version and that every locked module was installed. It also keeps the app bootstrap manifest check as a second guard for required modules.

## Testing
- Parsed `.github/workflows/sync-version-with-upstream.yml` and `snap/snapcraft.yaml` with Python/PyYAML
- Compiled `snap/local/bin/generate-discord-updater-manifest` with `py_compile`
- Regenerated `snap/local/discord-updater-modules.json` from Discord's matching `1.0.141` updater manifest and confirmed it matched the committed lock
- Ran the helper with the committed module lock; it installed `app-1.0.141` and all 12 locked modules
- Earlier stress run: helper installed the requested version 20/20 times across `1.0.140` and `1.0.141`