### PR TITLE
chore: exclude build updater from staged files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,6 +36,8 @@ parts:
     plugin: dump
     source: snap/local
     source-type: local
+    stage:
+      - -bin/generate-discord-updater-manifest
     stage-packages:
       - jq
 


### PR DESCRIPTION
## Summary
- exclude `bin/generate-discord-updater-manifest` from the `launcher` part staging list
- keep the build-time updater script available in the source tree for snapcraft builds

## Validation
- `uv run --with pyyaml python -c "import yaml; data=yaml.safe_load(open('snap/snapcraft.yaml')); print(data['parts']['launcher']['stage'])"`
- `git diff --check`

`snapcraft` is not installed in this environment, so I could not run `snapcraft expand-extensions` or a local snap build.