### PR TITLE
fix: expose standalone modules to electron

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -122,6 +122,9 @@ apps:
       # Correct the TMPDIR path for Chromium Framework/Electron to
       # ensure libappindicator has readable resources
       TMPDIR: $XDG_RUNTIME_DIR
+      # Let Electron preload/renderer processes resolve bundled standalone
+      # updater modules such as discord_krisp with require('discord_krisp').
+      NODE_PATH: $SNAP/usr/share/discord/resources/standalone_modules
     plugs:
       - audio-playback
       - audio-record


### PR DESCRIPTION
## Summary
- add `NODE_PATH` for the Discord app so Electron preload/renderer processes can resolve bundled standalone modules
- this lets `require('discord_krisp')` find the staged `resources/standalone_modules/discord_krisp` package instead of failing with `MODULE_NOT_FOUND`

## Local testing
- `snap download discord --channel=stable --target-directory=/tmp --basename=discord-stable`
- extracted the stable snap and confirmed `discord_krisp` is present under `usr/share/discord/resources/standalone_modules/discord_krisp`
- reproduced Node module resolution from the `discord_desktop_core` module directory:
  - without `NODE_PATH`: `MODULE_NOT_FOUND: Cannot find module 'discord_krisp'`
  - with `NODE_PATH=/tmp/discord-stable-extract/usr/share/discord/resources/standalone_modules`: resolves to `.../standalone_modules/discord_krisp/index.js`
- `python3` YAML assertion: `apps.discord.environment.NODE_PATH` is configured as `$SNAP/usr/share/discord/resources/standalone_modules`
- `git diff --check`
- `snapcraft expand-extensions` and verified the expanded project preserves `NODE_PATH`
- `snapcraft pack` using the managed LXD provider: built `discord_1.0.142_amd64.snap`

Fixes #343

@jnsgruk for review when ready.