### PR TITLE
Ensure Krisp KMS logs directory exists

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -83,16 +83,7 @@ parts:
       # Krisp expects this directory to exist relative to the discord_krisp
       # module. If absent, Krisp global init fails with error code -4:
       # NoiseCancellerError.KRISP_INIT_ERROR_GLOBAL_INIT.
-      krisp_dir="${CRAFT_PART_INSTALL}/usr/share/discord/resources/standalone_modules/discord_krisp"
-      if [ ! -d "${krisp_dir}" ]; then
-        echo "discord_krisp module missing at expected path: ${krisp_dir}"
-        exit 1
-      fi
-      mkdir -p "${krisp_dir}/KMS/logs"
-      if [ ! -d "${krisp_dir}/KMS/logs" ]; then
-        echo "Failed to create Krisp logs directory: ${krisp_dir}/KMS/logs"
-        exit 1
-      fi
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/discord/resources/standalone_modules/discord_krisp/KMS/logs"
 
       jq '.standaloneModules = true' \
         "${CRAFT_PART_INSTALL}/usr/share/discord/resources/build_info.json" \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -79,6 +79,21 @@ parts:
         mv "$module_dir/$name" "${CRAFT_PART_INSTALL}/usr/share/discord/resources/standalone_modules/$name"
       done
       rm -rf "${CRAFT_PART_INSTALL}/usr/share/discord/modules"
+
+      # Krisp expects this directory to exist relative to the discord_krisp
+      # module. If absent, Krisp global init fails with error code -4:
+      # NoiseCancellerError.KRISP_INIT_ERROR_GLOBAL_INIT.
+      krisp_dir="${CRAFT_PART_INSTALL}/usr/share/discord/resources/standalone_modules/discord_krisp"
+      if [ ! -d "${krisp_dir}" ]; then
+        echo "discord_krisp module missing at expected path: ${krisp_dir}"
+        exit 1
+      fi
+      mkdir -p "${krisp_dir}/KMS/logs"
+      if [ ! -d "${krisp_dir}/KMS/logs" ]; then
+        echo "Failed to create Krisp logs directory: ${krisp_dir}/KMS/logs"
+        exit 1
+      fi
+
       jq '.standaloneModules = true' \
         "${CRAFT_PART_INSTALL}/usr/share/discord/resources/build_info.json" \
         > /tmp/build_info.json


### PR DESCRIPTION
## Summary
- create `discord_krisp/KMS/logs` in the snap payload after standalone module flattening
- fail the build clearly if `discord_krisp` is not present at the expected standalone module path

## Test Plan
- `git diff --check`
- `python3` static assertions for the new Krisp path/checks in `snap/snapcraft.yaml`
- `snapcraft clean discord || true && snapcraft pack --use-lxd`
- `sudo snap install --dangerous ./discord_1.0.143_amd64.snap`
- `snap run --shell discord -c 'ls -ld "$SNAP/usr/share/discord/resources/standalone_modules/discord_krisp" "$SNAP/usr/share/discord/resources/standalone_modules/discord_krisp/KMS" "$SNAP/usr/share/discord/resources/standalone_modules/discord_krisp/KMS/logs"'`

Runtime Krisp toggle testing was not run locally because this host session has no GUI display available (`DISPLAY`/`WAYLAND_DISPLAY` unset).

@jnsgruk