### PR TITLE
fix: stop duplicating Discord desktop MIME type

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,9 +51,6 @@ parts:
       # Fix the .desktop file icon path for the snap.
       sed -i 's|Icon=discord|Icon=/usr/share/discord/discord\.png|' ${CRAFT_PART_INSTALL}/usr/share/discord/discord.desktop
 
-      # Inject the missing MIME type into the desktop file so links work
-      sed -i 's/^Categories=.*/&\nMimeType=x-scheme-handler\/discord;/' ${CRAFT_PART_INSTALL}/usr/share/discord/discord.desktop
-
       # The upstream .deb doesn't contain the actual Discord app — only a
       # bootstrapper (updater_bootstrap) that normally downloads Discord into
       # the user's home directory at runtime. Since snap confinement prevents


### PR DESCRIPTION
## Summary
- remove the build-time `MimeType=x-scheme-handler/discord;` injection from `snap/snapcraft.yaml`
- keep the Discord 1.0.144 release aligned with the upstream `.desktop` file, which now already declares the Discord URL scheme handler
- avoid Snapcraft metadata extraction failing on a duplicate `MimeType` key

## Findings
The failed Release run for `1.0.144` failed while Snapcraft was extracting desktop metadata:

```text
While reading from PosixPath('/build/.../prime/usr/share/applications/discord.desktop') [line 11]: option 'MimeType' in section 'Desktop Entry' already exists
```

PR #350 added a sed patch because the `1.0.143` upstream desktop file did not include the Discord URL scheme handler. That intent was correct at the time, but the `1.0.144` upstream `.deb` now ships:

```ini
Exec=/usr/bin/discord --url -- %u
MimeType=x-scheme-handler/discord;
```

With that upstream change in place, the snapcraft sed patch adds a second `MimeType` line and makes the desktop file invalid for Snapcraft's strict parser. Since upstream now carries the handler, this PR removes the local injection rather than making it conditional.

@jnsgruk could you review?

## Test Plan
- `git diff --check`
- parsed `snap/snapcraft.yaml` with Python/YAML to confirm it remains valid
- inspected upstream Discord `1.0.143` and `1.0.144` `.deb` desktop files; confirmed `1.0.144` includes `MimeType=x-scheme-handler/discord;`
