### PR TITLE
fix: call uv through astral-uv snap command

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -108,7 +108,7 @@ parts:
     plugin: nil
     build-snaps: [astral-uv]
     override-build: |
-      uv run \
+      astral-uv.uv run \
         https://raw.githubusercontent.com/snapcrafters/patch-desktop-file-name/refs/heads/main/electron/patch-desktop-filename.py \
         "${CRAFT_STAGE}/usr/share/discord/resources/app.asar"
 


### PR DESCRIPTION
## Summary
- call the Astral uv build-snap via its exported `astral-uv.uv` command
- fixes the release build failure where the scriptlet could not find `uv`

## Test plan
- `git diff --check`
- `snapcraft expand-extensions` confirms the patched command is accepted in the expanded project
- `snapcraft clean && snapcraft pack --use-lxd` built `discord_1.0.145_amd64.snap` locally
- `sudo snap install --dangerous ./discord_1.0.145_amd64.snap`
- `snap run discord --version` printed `Discord 1.0.145` before exiting due to the headless host missing X/$DISPLAY

@jnsgruk
