### PR TITLE
Add personal-files plug for steam (#359)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -116,6 +116,10 @@ plugs:
   shmem:
     interface: shared-memory
     private: true
+  dot-local-share-steam:
+    interface: personal-files
+    read:
+      - $HOME/.local/share/Steam
 
 apps:
   discord:
@@ -135,6 +139,7 @@ apps:
       - audio-playback
       - audio-record
       - camera
+      - dot-local-share-steam
       - home
       - mount-observe
       - network


### PR DESCRIPTION
Files in .local are not able to be dragged and dropped into a Discord message box - however, Steam screenshots are stored in ~/.local/share/Steam, which is where players are directed if they want to view files on their system. Thus, dragging and dropping from there is likely a use case that we want to support for Discord's target userbase.

It may be worth adding an autoconnect assertion for $HOME/.local/share/Steam to this end as well.